### PR TITLE
Fix SIGABRT in ddvd_mpa_compute_scale_factors on OOB scale factor index

### DIFF
--- a/mpegaudio_enc.c
+++ b/mpegaudio_enc.c
@@ -330,7 +330,14 @@ static void ddvd_mpa_compute_scale_factors(unsigned char ddvd_mpa_scale_code[SBL
                    use at most 2 compares to find the index */
                 index = (21 - n) * 3 - 3;
                 if (index >= 0) {
-                    while (vmax <= ddvd_mpa_scale_factor_table[index+1])
+                    /* bound the loop: index+1 must stay within the
+                       64-entry table. On some hardware (Hisilicon
+                       boxes w/ missing STC/sync drivers) vmax can
+                       end up smaller than every remaining table
+                       entry, overrunning the array and tripping the
+                       assert below with SIGABRT. */
+                    while (index < 62 &&
+                           vmax <= ddvd_mpa_scale_factor_table[index+1])
                         index++;
                 } else {
                     index = 0; /* very unlikely case of overflow */
@@ -338,6 +345,8 @@ static void ddvd_mpa_compute_scale_factors(unsigned char ddvd_mpa_scale_code[SBL
             } else {
                 index = 62; /* value 63 is not allowed */
             }
+            if (index > 62)
+                index = 62; /* value 63 is not allowed */
 
 #if 0
             printf("%2d:%d in=%x %x %d\n",


### PR DESCRIPTION
The unbounded while-loop could advance index past 62, causing an out-of-bounds read on ddvd_mpa_scale_factor_table[index+1] and tripping the assert with SIGABRT on hardware where vmax ends up smaller than every remaining table entry (e.g. Hisilicon boxes with missing /proc/stb/pcr/pcr_stc_offset and sync_offset drivers).

Bound the loop to index < 62 and clamp afterwards, consistent with the existing 'value 63 is not allowed' comment.

Refs: openatv/enigma2#2861